### PR TITLE
Refactor brain-intake: separate responsibilities, add docs & migration plan

### DIFF
--- a/skills/brain-intake/MIGRATION.md
+++ b/skills/brain-intake/MIGRATION.md
@@ -1,0 +1,21 @@
+# MIGRATION / REMOVAL Guide — brain-intake
+
+当决定移除或重构 brain-intake 时的步骤：
+
+1. 备份现有 brain_file
+  - 在 ${BRAIN_SOURCE}/backup/ 保存所有受影响的 brain_file 副本
+
+2. 导出未完成的行动项
+  - 扫描各项目 README 中的 "行动项" 部分，收集未勾选的条目。
+  - 将其汇总到 /tmp/brain_intake_actions_<timestamp>.md
+
+3. 将行动项迁移为 Issues（可选）
+  - 使用 new-issue 批量创建 issues，或由用户手动创建。
+
+4. 删除或重命名旧 skill 目录
+  - 将 skills/brain-intake/ 重命名为 skills/brain-intake.bak（保留历史）
+
+5. 回退
+  - 若需回退：恢复备份文件并将 skills/brain-intake.bak 恢复为原名，revert 对应 PR。
+
+注意：任何自动迁移步骤必须先征得用户确认。

--- a/skills/brain-intake/PRD.md
+++ b/skills/brain-intake/PRD.md
@@ -1,0 +1,34 @@
+# PRD: brain-intake Skill Refactor
+
+背景
+当前 brain-intake 与 new-issue 在职责上存在重叠（如 action item -> issue 的直创建），导致维护成本和不确定性。目标是将两者严格分离，降低耦合并提供明确的迁移路径。
+
+目标
+- 明确职责边界，移除直接创建 Issue 的行为
+- 提供可测试的输入/输出接口
+- 完整的文档和迁移计划
+
+功能需求
+Must:
+- 输入解析、项目匹配、历史对比、结论/行动提取、写入 brain_file、预览与确认
+- 对冲突进行交互式处理
+- 生成可被 new-issue 使用的 action list（但不自动创建 issue）
+
+Nice-to-have:
+- 可选交互：确认后调用 new-issue（通过明确的用户授权）
+- 单元测试与 CI 校验
+
+迁移与回退
+- 在 PR 中保留原始 skill 文件副本
+- 提供 MIGRATION.md 指南，导出未完成 action 并转为 issues（由用户或 new-issue 执行）
+
+里程碑
+1. 设计文档 & README（本次提交）
+2. 实现：解析器与提取逻辑的重构
+3. 测试：单元测试、集成示例
+4. PR 提交与 review
+
+验收准则
+- 提交设计文档并在仓库中新增/更新 skill 文件
+- 提交包含代码与文档改动的 PR（或多个分阶段 PR）并列出回滚步骤
+- 新增的内容包含基本测试或验证步骤

--- a/skills/brain-intake/README.md
+++ b/skills/brain-intake/README.md
@@ -1,0 +1,30 @@
+# brain-intake Skill — Refactor Draft
+
+目的：明确 brain-intake 的职责为“项目归档与 intake 流程”，并移除 issue-creation 职责（由 new-issue 负责）。
+
+职责边界
+- brain-intake: 负责接收项目相关内容，将结论、行动项、未决问题整理并追加到项目的 brain_file（项目 README 指定位置）。负责匹配项目、对比历史、提取结论与行动项、生成写入预览并在用户确认后写入并 push。
+- new-issue: 负责作为 PM 风格的 GitHub issue 创建器；当需要将行动项转换为 issue，必须由 new-issue 在用户确认后创建。
+
+输入与接口
+- 支持输入格式：plain text / markdown / URL / transcript
+- 必需字段（建议）：
+  - project_hint (可选): 项目 id/name 的提示
+  - content: 要归档的文本
+  - source (可选): 来源（如 slack, email, meeting）
+  - author (可选)
+
+主要流程
+1. 匹配项目（registry.yml）
+2. 加载项目历史（brain_file）
+3. 检测冲突/矛盾并提示用户
+4. 提取：结论 (1-3)，行动项，未决问题
+5. 预览并征求用户确认
+6. 在确认后写入 brain_file（并可选触发 new-issue 创建 issues）并 push
+
+示例片段
+职责边界示例：
+> brain-intake 负责把项目相关结论与行动归档到 external brain 的 README（brain_file），并在需要时生成可供 new-issue 创建 issue 的待办列表；绝不直接创建 GitHub issue 或替代 new-issue 的 PM 职责。
+
+验收标准引用
+详见 issue #32

--- a/skills/brain-intake/tests/ci-check.sh
+++ b/skills/brain-intake/tests/ci-check.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# 简单自检脚本示例
+set -e
+echo "Running simple checks for brain-intake skill..."
+# check markdown files exist
+for f in README.md PRD.md MIGRATION.md; do
+  if [ ! -f "skills/brain-intake/$f" ]; then
+    echo "Missing $f"
+    exit 2
+  fi
+done
+echo "OK"

--- a/skills/brain-intake/tests/simple_parse.test.md
+++ b/skills/brain-intake/tests/simple_parse.test.md
@@ -1,0 +1,15 @@
+# simple_parse.test.md
+
+示例输入：
+```
+Project: bunny_stack
+Content: 我们决定使用 X 作为默认 auth 方案。需要在 README 中记录并创建一个迁移任务。
+Source: meeting 2026-03-24
+```
+
+预期输出：
+- Conclusions:
+  → 使用 X 作为默认 auth 方案
+- Action items:
+  - [ ] 在 README 中添加 auth 方案说明
+  - [ ] 创建迁移任务（待 new-issue 创建 issue）


### PR DESCRIPTION
Draft PR: add README, PRD, MIGRATION guide, and simple tests for brain-intake skill. See issue #32 for background.\n\nThis PR does not change runtime code; it provides design docs and migration guidance for refactoring or removing the skill.